### PR TITLE
Use system default settings building http client

### DIFF
--- a/src/main/java/be/ugent/IfcSpfReader.java
+++ b/src/main/java/be/ugent/IfcSpfReader.java
@@ -203,7 +203,7 @@ public class IfcSpfReader {
 
 		InputStream in = null;
 		try {
-			HttpOp.setDefaultHttpClient(HttpClientBuilder.create().build());
+			HttpOp.setDefaultHttpClient(HttpClientBuilder.create().useSystemProperties().build());
 			om = ModelFactory.createOntologyModel(OntModelSpec.OWL_DL_MEM_TRANS_INF);
 			in = IfcSpfReader.class.getResourceAsStream("/" + exp + ".ttl");
 			om.read(in, null, "TTL");


### PR DESCRIPTION
We noticed a problem using this tool behind our corporate proxy. While building with maven worked flawlessly the application itself did not respect the system configured proxy settings and timed out on network requests. This commit aims to fix that.