### PR TITLE
ISSUE-34: Generate in-memory RDF graph

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -329,9 +329,9 @@
         <!-- Dependencies -->
         <commons-io.version>2.4</commons-io.version>
         <slf4j-api.version>1.7.7</slf4j-api.version>
-        <junit.version>4.13.1</junit.version>
+        <org.junit.jupiter.version>5.7.2</org.junit.jupiter.version>
         <slf4j-log4j12.version>1.7.7</slf4j-log4j12.version>
-        <jena.version>3.1.1</jena.version>
+        <jena.version>4.1.0</jena.version>
         <expresstoowl.version>0.4</expresstoowl.version>
         <!-- Maven Plugin Dependencies -->
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
@@ -395,9 +395,9 @@
         </dependency>
         <!-- Test dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${org.junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/be/ugent/IfcSpfReader.java
+++ b/src/main/java/be/ugent/IfcSpfReader.java
@@ -234,9 +234,8 @@ public class IfcSpfReader {
         exp = getExpressSchema(ifcFile);
 
         // check if we are able to convert this: only four schemas are supported
-        if (!exp.equalsIgnoreCase("IFC2X3_Final") && !exp.equalsIgnoreCase("IFC2X3_TC1") && !exp.equalsIgnoreCase("IFC4_ADD2_TC1")
-				&& !exp.equalsIgnoreCase("IFC4_ADD2") && !exp.equalsIgnoreCase("IFC4_ADD1") && !exp.equalsIgnoreCase("IFC4")
-                        && !exp.equalsIgnoreCase("IFC4x1") && !exp.equalsIgnoreCase("IFC4x3_RC1")) {
+        if (!exp.equalsIgnoreCase("IFC2X3_Final") && !exp.equalsIgnoreCase("IFC2X3_TC1") && !exp.equalsIgnoreCase("IFC4_ADD2_TC1") && !exp.equalsIgnoreCase("IFC4_ADD2")
+                        && !exp.equalsIgnoreCase("IFC4_ADD1") && !exp.equalsIgnoreCase("IFC4") && !exp.equalsIgnoreCase("IFC4x1") && !exp.equalsIgnoreCase("IFC4x3_RC1")) {
             LOG.error("Unrecognised EXPRESS schema: " + exp + ". File should be in IFC4x3_RC1, IFC4X1, IFC4, IFC4_ADD1, IFC4_ADD2, IFC4_ADD2_TC1 or IFC2X3 schema. Quitting." + "\r\n");
         }
 

--- a/src/main/java/be/ugent/IfcSpfReader.java
+++ b/src/main/java/be/ugent/IfcSpfReader.java
@@ -29,12 +29,14 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.ontology.OntModel;
 import org.apache.jena.ontology.OntModelSpec;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.system.StreamRDF;
 import org.apache.jena.riot.web.HttpOp;
 import org.apache.jena.sparql.graph.GraphFactory;
 import org.slf4j.Logger;
@@ -306,39 +308,34 @@ public class IfcSpfReader {
 
     @SuppressWarnings("unchecked")
 	public void convert(String ifcFile, String outputFile, String baseURI) throws IOException {
-		// CONVERSION
-		OntModel om = null;
-
-		in = null;
-		HttpOp.setDefaultHttpClient(HttpClientBuilder.create().useSystemProperties().build());
-		om = ModelFactory.createOntologyModel(OntModelSpec.OWL_DL_MEM_TRANS_INF);
-		in = IfcSpfReader.class.getResourceAsStream("/" + exp + ".ttl");
-		if (in == null)
-			in = IfcSpfReader.class.getResourceAsStream("/resources/" + exp + ".ttl");  // Eclipse FIX
-		
-		om.read(in, null, "TTL");
-
-		try {
-			RDFWriter conv = new RDFWriter(om, new FileInputStream(ifcFile), baseURI, ent, typ, ontURI);
-			conv.setRemoveDuplicates(removeDuplicates);
+    	convert(ifcFile, baseURI, writer -> {
 			try (FileOutputStream out = new FileOutputStream(outputFile)) {
 				String s = "# baseURI: " + baseURI;
 				s += "\r\n# imports: " + ontURI + "\r\n\r\n";
 				out.write(s.getBytes());
 				LOG.info("Started parsing stream");
-				conv.parseModelToOutputStream(out);
+				writer.parseModelToOutputStream(out);
 				LOG.info("Finished!!");
+			} catch (Exception e) {
+				throw new RuntimeException(String.format("Could not write output %s: %s", outputFile, e.getMessage() ));
 			}
-		} catch (FileNotFoundException e1) {
-			e1.printStackTrace();
-		} finally {
-			try {
-				in.close();
-			} catch (Exception e1) {
-				e1.printStackTrace();
-			}
+		});
+	}
+
+	public void convert(String ifcFile, String baseURI, Consumer<RDFWriter> handler){
+		// CONVERSION
+		OntModel om = readOntology();
+		try (InputStream in = new FileInputStream(ifcFile)){
+			RDFWriter conv = new RDFWriter(om, in, baseURI, ent, typ, ontURI);
+			conv.setRemoveDuplicates(removeDuplicates);
+			LOG.info("Started parsing stream");
+			handler.accept(conv);
+			LOG.info("Finished!!");
+		} catch (Exception e) {
+			throw new RuntimeException(String.format("Error converting file %s: %s", ifcFile, e.getMessage()));
 		}
 	}
+
 
 	public Graph convert(String ifcFile, String baseURI) throws IOException {
 		Graph graph = GraphFactory.createGraphMem();
@@ -348,31 +345,35 @@ public class IfcSpfReader {
 
 	@SuppressWarnings("unchecked")
 	public void convert(String ifcFile, Graph toGraph, String baseURI) throws IOException {
-		// CONVERSION
-		OntModel om = null;
+		convert(ifcFile, baseURI, writer -> {
+			try {
+				writer.parseModelToGraph(toGraph);
+			} catch (Exception e) {
+				throw new RuntimeException(String.format("Error converting file %s: %s", ifcFile, e.getMessage()));
+			}
+		});
+	}
 
+	public void convert(String ifcFile, StreamRDF streamRDF, String baseURI) throws IOException {
+		convert(ifcFile, baseURI, writer -> {
+			try {
+				writer.parseModelToStreamRdf(streamRDF);
+			} catch (Exception e) {
+				throw new RuntimeException(String.format("Error converting file %s: %s", ifcFile, e.getMessage()));
+			}
+		});
+	}
+
+	private OntModel readOntology() {
+		OntModel om = null;
 		in = null;
 		HttpOp.setDefaultHttpClient(HttpClientBuilder.create().useSystemProperties().build());
 		om = ModelFactory.createOntologyModel(OntModelSpec.OWL_DL_MEM_TRANS_INF);
 		in = IfcSpfReader.class.getResourceAsStream("/" + exp + ".ttl");
 		if (in == null)
 			in = IfcSpfReader.class.getResourceAsStream("/resources/" + exp + ".ttl");  // Eclipse FIX
-
 		om.read(in, null, "TTL");
-
-		try {
-			RDFWriter conv = new RDFWriter(om, new FileInputStream(ifcFile), baseURI, ent, typ, ontURI);
-			conv.setRemoveDuplicates(removeDuplicates);
-			LOG.info("Started parsing stream");
-			conv.parseModelToGraph(toGraph);
-			LOG.info("Finished!!");
-		} finally {
-			try {
-				in.close();
-			} catch (Exception e1) {
-				e1.printStackTrace();
-			}
-		}
+		return om;
 	}
 
     public void setRemoveDuplicates(boolean val) {

--- a/src/main/java/be/ugent/RDFWriter.java
+++ b/src/main/java/be/ugent/RDFWriter.java
@@ -103,6 +103,11 @@ public class RDFWriter {
     parseModelToOutputStream();
   }
 
+  public void parseModelToStreamRdf(StreamRDF writer) throws IOException {
+    ttlWriter = writer;
+    parseModelToOutputStream();
+  }
+
   private void parseModelToOutputStream() throws IOException {
     ttlWriter.base(baseURI);
     ttlWriter.prefix("ifc", ontNS);

--- a/src/main/java/be/ugent/RDFWriter.java
+++ b/src/main/java/be/ugent/RDFWriter.java
@@ -162,10 +162,11 @@ public class RDFWriter {
       }
       listOfUniqueResources.put(ifcLineEntry.getFullLineAfterNum(), r);
 
-      LOG.info("-------------------------------");
-      LOG.info(r.getLocalName());
-      LOG.info("-------------------------------");
-
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("-------------------------------");
+        LOG.debug(r.getLocalName());
+        LOG.debug("-------------------------------");
+      }
       fillProperties(ifcLineEntry, r);
     }
     // The map is used only to avoid duplicates.
@@ -202,7 +203,9 @@ public class RDFWriter {
         } else if (IFCVO.class.isInstance(o)) {
           LOG.warn("*WARNING 2*: fillProperties 2: unhandled type property found.");
         } else if (LinkedList.class.isInstance(o)) {
-          LOG.info("fillProperties 3 - fillPropertiesHandleListObject(tvo)");
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("fillProperties 3 - fillPropertiesHandleListObject(tvo)");
+          }
           fillPropertiesHandleListObject(r, tvo, o);
         }
       }
@@ -221,13 +224,19 @@ public class RDFWriter {
             LOG.error("*ERROR 18*: We found a character that is not a comma. That should not be possible!");
           }
         } else if (String.class.isInstance(o)) {
-          LOG.info("fillProperties 4 - fillPropertiesHandleStringObject(evo)");
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("fillProperties 4 - fillPropertiesHandleStringObject(evo)");
+          }
           attributePointer = fillPropertiesHandleStringObject(r, evo, subject, attributePointer, o);
         } else if (IFCVO.class.isInstance(o)) {
-          LOG.info("fillProperties 5 - fillPropertiesHandleIfcObject(evo)");
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("fillProperties 5 - fillPropertiesHandleIfcObject(evo)");
+          }
           attributePointer = fillPropertiesHandleIfcObject(r, evo, attributePointer, o);
         } else if (LinkedList.class.isInstance(o)) {
-          LOG.info("fillProperties 6 - fillPropertiesHandleListObject(evo)");
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("fillProperties 6 - fillPropertiesHandleListObject(evo)");
+          }
           attributePointer = fillPropertiesHandleListObject(r, evo, attributePointer, o);
         }
       }
@@ -260,17 +269,22 @@ public class RDFWriter {
               addEnumProperty(r, p, range, literalString);
             } else if (range.asClass().hasSuperClass(ontModel.getOntClass(EXPRESS_NS + "SELECT"))) {
               // Check for SELECT
-              LOG.info("*OK 25*: found subClass of SELECT Class, now doing nothing with it: " + p + " - " + range.getLocalName() + " - " + literalString);
+              if (LOG.isDebugEnabled()) {
+                LOG.debug("*OK 25*: found subClass of SELECT Class, now doing nothing with it: {} - {} - {}", p,
+                                range.getLocalName(), literalString);
+              }
               createLiteralProperty(r, p, range, literalString);
             } else if (range.asClass().hasSuperClass(ontModel.getOntClass(LIST_NS + "OWLList"))) {
               // Check for LIST
-              LOG.info("*WARNING 5*: found LIST property (but doing nothing with it): " + subject + " -- " + p + " - " + range.getLocalName() + " - "
-                      + literalString);
+              if (LOG.isDebugEnabled()) {
+                LOG.debug("*WARNING 5*: found LIST property (but doing nothing with it): {} -- {} - {} - {}",
+                                new Object[] { subject, p, range.getLocalName(), literalString });
+              }
             } else {
               createLiteralProperty(r, p, range, literalString);
             }
           } else {
-            LOG.warn("*WARNING 7*: found other kind of property: " + p + " - " + range.getLocalName());
+            LOG.warn("*WARNING 7*: found other kind of property: {} - {}", p ,range.getLocalName());
           }
         } else {
           LOG.warn("*WARNING 8*: Nothing happened. Not sure if this is good or bad, possible or not.");
@@ -295,7 +309,9 @@ public class RDFWriter {
 
       Resource r1 = getResource(baseURI + evorange.getName() + "_" + ((IFCVO) o).getLineNum(), rclass);
       ttlWriter.triple(new Triple(r.asNode(), p.asNode(), r1.asNode()));
-      LOG.info("*OK 1*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r1.getLocalName());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("*OK 1*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r1.getLocalName());
+      }
     } else {
       LOG.warn("*WARNING 3*: Nothing happened. Not sure if this is good or bad, possible or not.");
     }
@@ -364,7 +380,11 @@ public class RDFWriter {
 
             Resource r1 = getResource(baseURI + evorange.getName() + "_" + ((IFCVO) o1).getLineNum(), rclass);
             ttlWriter.triple(new Triple(r.asNode(), p.asNode(), r1.asNode()));
-            LOG.info("*OK 5*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r1.getLocalName());
+            if (LOG.isDebugEnabled()) {
+              LOG.debug("*OK 5*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r1
+                              .getLocalName());
+            }
+
           }
         } else {
           LOG.warn("*WARNING 13*: Nothing happened. Not sure if this is good or bad, possible or not.");
@@ -619,7 +639,10 @@ public class RDFWriter {
         addEnumProperty(r, p, range, literalString);
       } else if (range.asClass().hasSuperClass(ontModel.getOntClass(EXPRESS_NS + "SELECT"))) {
         // Check for SELECT
-        LOG.info("*OK 24*: found subClass of SELECT Class, now doing nothing with it: " + p + " - " + range.getLocalName() + " - " + literalString);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("*OK 24*: found subClass of SELECT Class, now doing nothing with it: " + p + " - " + range
+                          .getLocalName() + " - " + literalString);
+        }
         createLiteralProperty(r, p, range, literalString);
       } else if (range.asClass().hasSuperClass(ontModel.getOntClass(LIST_NS + "OWLList"))) {
         // Check for LIST
@@ -637,7 +660,10 @@ public class RDFWriter {
       OntResource rangeInstance = instances.next();
       if (rangeInstance.getProperty(RDFS.label).getString().equalsIgnoreCase(filterPoints(literalString))) {
         ttlWriter.triple(new Triple(r.asNode(), p.asNode(), rangeInstance.asNode()));
-        LOG.info("*OK 2*: added ENUM statement " + r.getLocalName() + " - " + p.getLocalName() + " - " + rangeInstance.getLocalName());
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("*OK 2*: added ENUM statement " + r.getLocalName() + " - " + p.getLocalName() + " - "
+                          + rangeInstance.getLocalName());
+        }
         return;
       }
     }
@@ -671,8 +697,9 @@ public class RDFWriter {
       addLiteral(r1, valueProp, ResourceFactory.createTypedLiteral(literalString, XSDDatatype.XSDstring));
     else
       addLiteral(r1, valueProp, ResourceFactory.createTypedLiteral(literalString));
-
-    LOG.info("*OK 4*: added literal: " + r1.getLocalName() + " - " + valueProp + " - " + literalString);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("*OK 4*: added literal: " + r1.getLocalName() + " - " + valueProp + " - " + literalString);
+    }
   }
 
   // LIST HANDLING
@@ -709,14 +736,22 @@ public class RDFWriter {
             EntityVO evorange = ent.get(ExpressReader.formatClassName((vo).getName()));
             OntResource rclass = ontModel.getOntResource(ontNS + evorange.getName());
             Resource r2 = getResource(baseURI + evorange.getName() + "_" + (vo).getLineNum(), rclass);
-            LOG.info("*OK 21*: created resource: " + r2.getLocalName());
+            if (LOG.isDebugEnabled()) {
+              LOG.debug("*OK 21*: created resource: " + r2.getLocalName());
+            }
             idCounter++;
             ttlWriter.triple(new Triple(r1.asNode(), ontModel.getOntProperty(LIST_NS + "hasContents").asNode(), r2.asNode()));
-            LOG.info("*OK 22*: added property: " + r1.getLocalName() + " - " + "-hasContents-" + " - " + r2.getLocalName());
+            if (LOG.isDebugEnabled()) {
+              LOG.debug("*OK 22*: added property: " + r1.getLocalName() + " - " + "-hasContents-" + " - " + r2
+                              .getLocalName());
+            }
 
             if (i < el.size() - 1) {
               ttlWriter.triple(new Triple(r1.asNode(), ontModel.getOntProperty(LIST_NS + "hasNext").asNode(), reslist.get(i + 1).asNode()));
-              LOG.info("*OK 23*: added property: " + r1.getLocalName() + " - " + "-hasNext-" + " - " + reslist.get(i + 1).getLocalName());
+              if (LOG.isDebugEnabled()) {
+                LOG.debug("*OK 23*: added property: " + r1.getLocalName() + " - " + "-hasNext-" + " - " + reslist
+                                .get(i + 1).getLocalName());
+              }
             }
           }
         }
@@ -747,7 +782,10 @@ public class RDFWriter {
             idCounter++;
             if (ii == 0) {
               ttlWriter.triple(new Triple(r.asNode(), p.asNode(), r1.asNode()));
-              LOG.info("*OK 7*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r1.getLocalName());
+              if (LOG.isDebugEnabled()) {
+                LOG.debug("*OK 7*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r1
+                                .getLocalName());
+              }
             }
           }
           // bindtheproperties
@@ -771,13 +809,17 @@ public class RDFWriter {
       if (r1 == null) {
         r1 = ResourceFactory.createResource(baseURI + range.getLocalName() + "_" + idCounter);
         ttlWriter.triple(new Triple(r1.asNode(), RDF.type.asNode(), range.asNode()));
-        LOG.info("*OK 17*: created resource: " + r1.getLocalName());
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("*OK 17*: created resource: " + r1.getLocalName());
+        }
         idCounter++;
         propertyResourceMap.put(key, r1);
         addLiteralToResource(r1, valueProp, xsdType, literalString);
       }
       ttlWriter.triple(new Triple(r.asNode(), p.asNode(), r1.asNode()));
-      LOG.info("*OK 3*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r1.getLocalName());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("*OK 3*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r1.getLocalName());
+      }
     } else {
       LOG.error("*ERROR 1*: XSD type not found for: " + p + " - " + range.getURI() + " - " + literalString);
     }
@@ -790,7 +832,9 @@ public class RDFWriter {
 
       if (listrange != null) {
         if (listrange.asClass().hasSuperClass(ontModel.getOntClass(LIST_NS + "OWLList"))) {
-          LOG.info("*OK 20*: Handling list of list");
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("*OK 20*: Handling list of list");
+          }
           listrange = range;
         }
         for (int i = 0; i < el.size(); i++) {
@@ -798,20 +842,30 @@ public class RDFWriter {
           Resource r2 = ResourceFactory.createResource(baseURI + range.getLocalName() + "_" + idCounter); // was
           // listrange
           ttlWriter.triple(new Triple(r2.asNode(), RDF.type.asNode(), range.asNode()));
-          LOG.info("*OK 14*: added property: " + r2.getLocalName() + " - rdf:type - " + range.getLocalName());
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("*OK 14*: added property: " + r2.getLocalName() + " - rdf:type - " + range.getLocalName());
+          }
           idCounter++;
           Resource r3 = ResourceFactory.createResource(baseURI + range.getLocalName() + "_" + idCounter);
 
           if (i == 0) {
             ttlWriter.triple(new Triple(r.asNode(), p.asNode(), r2.asNode()));
-            LOG.info("*OK 15*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r2.getLocalName());
+            if (LOG.isDebugEnabled()) {
+              LOG.debug("*OK 15*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r2
+                              .getLocalName());
+            }
           }
           ttlWriter.triple(new Triple(r2.asNode(), ontModel.getOntProperty(LIST_NS + "hasContents").asNode(), r1.asNode()));
-          LOG.info("*OK 16*: added property: " + r2.getLocalName() + " - " + "-hasContents-" + " - " + r1.getLocalName());
-
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("*OK 16*: added property: " + r2.getLocalName() + " - " + "-hasContents-" + " - " + r1
+                            .getLocalName());
+          }
           if (i < el.size() - 1) {
             ttlWriter.triple(new Triple(r2.asNode(), ontModel.getOntProperty(LIST_NS + "hasNext").asNode(), r3.asNode()));
-            LOG.info("*OK 17*: added property: " + r2.getLocalName() + " - " + "-hasNext-" + " - " + r3.getLocalName());
+            if (LOG.isDebugEnabled()) {
+              LOG.debug("*OK 17*: added property: " + r2.getLocalName() + " - " + "-hasNext-" + " - " + r3
+                              .getLocalName());
+            }
           }
         }
       }
@@ -831,7 +885,10 @@ public class RDFWriter {
         entlist.add((IFCVO) tmpList.get(i));
         if (i == 0) {
           ttlWriter.triple(new Triple(r.asNode(), p.asNode(), r1.asNode()));
-          LOG.info("*OK 13*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r1.getLocalName());
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("*OK 13*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r1
+                            .getLocalName());
+          }
         }
       }
     }
@@ -853,17 +910,26 @@ public class RDFWriter {
         rclass = ontModel.getOntResource(ontNS + typerange.getName());
         Resource r1 = getResource(baseURI + typerange.getName() + "_" + entlist.get(i).getLineNum(), rclass);
         ttlWriter.triple(new Triple(r.asNode(), listp.asNode(), r1.asNode()));
-        LOG.info("*OK 8*: created property: " + r.getLocalName() + " - " + listp.getLocalName() + " - " + r1.getLocalName());
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("*OK 8*: created property: " + r.getLocalName() + " - " + listp.getLocalName() + " - " + r1
+                          .getLocalName());
+        }
       } else {
         rclass = ontModel.getOntResource(ontNS + evorange.getName());
         Resource r1 = getResource(baseURI + evorange.getName() + "_" + entlist.get(i).getLineNum(), rclass);
         ttlWriter.triple(new Triple(r.asNode(), listp.asNode(), r1.asNode()));
-        LOG.info("*OK 9*: created property: " + r.getLocalName() + " - " + listp.getLocalName() + " - " + r1.getLocalName());
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("*OK 9*: created property: " + r.getLocalName() + " - " + listp.getLocalName() + " - " + r1
+                          .getLocalName());
+        }
       }
 
       if (i < reslist.size() - 1) {
         ttlWriter.triple(new Triple(r.asNode(), isfollowed.asNode(), reslist.get(i + 1).asNode()));
-        LOG.info("*OK 10*: created property: " + r.getLocalName() + " - " + isfollowed.getLocalName() + " - " + reslist.get(i + 1).getLocalName());
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("*OK 10*: created property: " + r.getLocalName() + " - " + isfollowed.getLocalName() + " - "
+                          + reslist.get(i + 1).getLocalName());
+        }
       }
     }
   }
@@ -886,17 +952,25 @@ public class RDFWriter {
         if (r2 == null) {
           r2 = ResourceFactory.createResource(baseURI + listrange.getLocalName() + "_" + idCounter);
           ttlWriter.triple(new Triple(r2.asNode(), RDF.type.asNode(), listrange.asNode()));
-          LOG.info("*OK 19*: created resource: " + r2.getLocalName());
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("*OK 19*: created resource: " + r2.getLocalName());
+          }
           idCounter++;
           propertyResourceMap.put(key, r2);
           addLiteralToResource(r2, valueProp, xsdType, literalString);
         }
         ttlWriter.triple(new Triple(r.asNode(), ontModel.getOntProperty(LIST_NS + "hasContents").asNode(), r2.asNode()));
-        LOG.info("*OK 11*: added property: " + r.getLocalName() + " - " + "-hasContents-" + " - " + r2.getLocalName());
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("*OK 11*: added property: " + r.getLocalName() + " - " + "-hasContents-" + " - " + r2
+                          .getLocalName());
+        }
 
         if (i < listelements.size() - 1) {
           ttlWriter.triple(new Triple(r.asNode(), ontModel.getOntProperty(LIST_NS + "hasNext").asNode(), reslist.get(i + 1).asNode()));
-          LOG.info("*OK 12*: added property: " + r.getLocalName() + " - " + "-hasNext-" + " - " + reslist.get(i + 1).getLocalName());
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("*OK 12*: added property: " + r.getLocalName() + " - " + "-hasNext-" + " - " + reslist.get(i + 1)
+                            .getLocalName());
+          }
         }
       }
     } else {

--- a/src/test/java/be/ugent/TestIfcSpfReader.java
+++ b/src/test/java/be/ugent/TestIfcSpfReader.java
@@ -152,7 +152,7 @@ public class TestIfcSpfReader {
             failForDifferentFileLength(lineInput, lineOutput);
             line++;
             if (!lineInput.equals(lineOutput)) {
-                Assertions.fail(String.format("Acutal output differs from expected output:\n" + "  input: file %s\n" + "  expected output file: %s\n" + "  difference at line %d\n"
+                Assertions.fail(String.format("Actual output differs from expected output:\n" + "  input: file %s\n" + "  expected output file: %s\n" + "  difference at line %d\n"
                                 + "  expected line:%s\n" + "    actual line:%s", testInputTTL, testOutputTTL, line, lineInput, lineOutput));
             }
         }

--- a/src/test/java/be/ugent/TestIfcSpfReader.java
+++ b/src/test/java/be/ugent/TestIfcSpfReader.java
@@ -1,11 +1,11 @@
 /*
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,15 +14,20 @@
  */
 package be.ugent;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.*;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  * @author lewismc
@@ -40,7 +45,7 @@ public class TestIfcSpfReader {
     /**
      * @throws java.lang.Exception
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         reader = new IfcSpfReader();
     }
@@ -48,7 +53,7 @@ public class TestIfcSpfReader {
     /**
      * @throws java.lang.Exception
      */
-    @After
+    @AfterEach
     public void tearDown() {
         reader = null;
     }
@@ -71,7 +76,7 @@ public class TestIfcSpfReader {
       sb.append(s);
       sb.append(", ");
     }
-    Assert.assertEquals(
+    Assertions.assertEquals(
             "20160414office_model_CV2_fordesign.ifc, 20160414office_model_CV2_fordesign.ttl, Barcelona_Pavilion.ifc, Barcelona_Pavilion.ttl, ootest.txt, ",
             sb.toString());
   }
@@ -93,23 +98,31 @@ public class TestIfcSpfReader {
      *             if there is an error executing
      *             {@link TestIfcSpfReader#compareFileContents(String, String)}
      */
-    @Test
-    public final void testConvertIFCFileToOutputTTL() throws IOException {
-        final List<String> inputFiles;
-        inputFiles = showAllFiles(getClass().getClassLoader().getResource("convertIFCFileToOutputTTL").getFile());
+    @ParameterizedTest
+    @MethodSource
+    public final void testConvertIFCFileToOutputTTL(File input, File expectedOutput) throws IOException {
+        final String outputFileBase;
+        final String outputFileNew;
+        outputFileBase = input.getAbsolutePath().substring(0, input.getAbsolutePath().length() - 4) + ".ttl";
+        outputFileNew = "target" + outputFileBase.split("convertIFCFileToOutputTTL")[1];
+        reader.setup(input.getAbsolutePath());
+        reader.convert(input.getAbsolutePath(), outputFileNew, "http://linkedbuildingdata.net/ifc/resources/");
+        compareFileContents(outputFileBase, outputFileNew);
+    }
 
+    public static Stream<Arguments> testConvertIFCFileToOutputTTL() {
+        final List<String> inputFiles;
+        inputFiles = showAllFiles(TestIfcSpfReader.class.getClassLoader().getResource("convertIFCFileToOutputTTL").getFile());
+        List<Arguments> result = new ArrayList();
         for (int i = 0; i < inputFiles.size(); ++i) {
             final String inputFile = inputFiles.get(i);
-            final String outputFileBase;
-            final String outputFileNew;
+            final String outputFile;
             if (inputFile.endsWith(".ifc")) {
-                outputFileBase = inputFile.substring(0, inputFile.length() - 4) + ".ttl";
-                outputFileNew = "target" + outputFileBase.split("convertIFCFileToOutputTTL")[1];
-                reader.setup(inputFile);
-                reader.convert(inputFile, outputFileNew, "http://linkedbuildingdata.net/ifc/resources/");
-                Assert.assertTrue(compareFileContents(outputFileBase, outputFileNew));
+                outputFile = inputFile.substring(0, inputFile.length() - 4) + ".ttl";
+                result.add(Arguments.of(new File(inputFile), new File(outputFile)));
             }
         }
+        return result.stream();
     }
 
     /**
@@ -124,29 +137,33 @@ public class TestIfcSpfReader {
      *             if there is an error loading method parameters
      * @throws URISyntaxException
      */
-    private boolean compareFileContents(String testInputTTL, String testOutputTTL) throws IOException {
+    private void compareFileContents(String testInputTTL, String testOutputTTL) throws IOException {
         FileInputStream finInput = new FileInputStream(testInputTTL);
-        @SuppressWarnings("resource")
-        BufferedReader brInput = new BufferedReader(new InputStreamReader(finInput));
-        StringBuilder sbInput = new StringBuilder();
-        String lineInput;
-        while ((lineInput = brInput.readLine()) != null) {
-            sbInput.append(lineInput);
-        }
-
         FileInputStream finOutput = new FileInputStream(testOutputTTL);
-        @SuppressWarnings("resource")
+        BufferedReader brInput = new BufferedReader(new InputStreamReader(finInput));
         BufferedReader brOutput = new BufferedReader(new InputStreamReader(finOutput));
-        StringBuilder sbOutput = new StringBuilder();
+        String lineInput;
         String lineOutput;
-        while ((lineOutput = brOutput.readLine()) != null) {
-            sbOutput.append(lineOutput);
+        int line = 0;
+        boolean reading = true;
+        while (reading) {
+            lineInput = brInput.readLine().trim();
+            lineOutput = brOutput.readLine().trim();
+            failForDifferentFileLength(lineInput, lineOutput);
+            line++;
+            if (!lineInput.equals(lineOutput)) {
+                Assertions.fail(String.format("Acutal output differs from expected output:\n" + "  input: file %s\n" + "  expected output file: %s\n" + "  difference at line %d\n"
+                                + "  expected line:%s\n" + "    actual line:%s", testInputTTL, testOutputTTL, line, lineInput, lineOutput));
+            }
         }
+    }
 
-        if (sbInput.toString().equals(sbOutput.toString())) {
-            return true;
-        } else {
-            return false;
+    private void failForDifferentFileLength(String lineInput, String lineOutput) {
+        if (lineInput == null && lineOutput != null) {
+            Assertions.fail("actual ouput file is longer than expected output file");
+        }
+        if (lineInput != null && lineOutput == null) {
+            Assertions.fail("actual ouput file is shorter than expected output file");
         }
     }
 


### PR DESCRIPTION
Issue:  #34 

This PR adapts the interface of RDFWriter slightly so it's possible to pass it a graph that the converted IFC content is written to.
This change is also used to adapt the tests.

PR Checklist:
*  [x] there is an open issue on the [IFCtoRDF issue tracker](https://github.com/pipauwel/IFCtoRDF/issues) which describes the problem or the improvement.
* [ ] the issue ID (`ISSUE-XXXX`)
  - [x] is referenced in the title of the pull request
  - [  ] and placed in front of your commit messages surrounded by square brackets (`[ISSUE-XXXX] Issue or pull request title`)
* [x] commits are squashed into a single one (or few commits for larger changes)
* [ ] IFCtoRDF is successfully built and unit tests pass by running `mvn clean test`
* [ ] there should be no conflicts when merging the pull request branch into the *recent* master branch. If there are conflicts, please try to rebase the pull request branch on top of a freshly pulled master branch.

Sorry:
* This PR is based on my previous one, #29, which is still pending. There is just one additional commit here.
* The tests fail because the test cases still need updating
* EDIT: Had to add another commit (write to StreamRDF)
* EDIT: Had to add another commit (improve logging)